### PR TITLE
added boolean consent value to user sync url where possible

### DIFF
--- a/src/Adhese.js
+++ b/src/Adhese.js
@@ -155,6 +155,13 @@ Adhese.prototype.removeRequestParameter = function(key, value) {
     }
 };
 
+Adhese.prototype.getBooleanConsent = function() {
+	try {
+		return this.request.tl[0];
+	} catch(e) {
+		return 'none';
+	}
+}
 
 /**
  * Function to add a string to an Adhese instance. This string will be appended to each request.

--- a/src/rtb/AppnexusUserSync.js
+++ b/src/rtb/AppnexusUserSync.js
@@ -5,7 +5,7 @@
 */
 Adhese.prototype.appnexusUserSync = function() {
     this.genericUserSync({
-        url: "https://ib.adnxs.com/getuid?https%3A%2F%2Fuser-sync.adhese.com%2Fhandlers%2Fappnexus%2Fuser_sync%3Fu%3D%24UID",
+        url: "https://ib.adnxs.com/getuid?https%3A%2F%2Fuser-sync.adhese.com%2Fhandlers%2Fappnexus%2Ftl%3D" + this.getBooleanConsent() + "%26user_sync%3Fu%3D%24UID",
         syncName: "appnexus",
         iframe: true,
         onload: option.onload 

--- a/src/rtb/GenericUserSync.js
+++ b/src/rtb/GenericUserSync.js
@@ -27,7 +27,7 @@ Adhese.prototype.genericUserSync = function(option) {
 				this.helper.createCookie(lastSyncCookieName, diff, (diff/option.syncRefreshPeriod));
 				// also create domain cookie, so do a request to an .adhese.com endpoint with the current domain as qs param
 			}
-			if (this.config && this.config.hostname) new Image().src = "https://user-sync.adhese.com/handlers/" + option.syncName + "/user_sync_discovery?domain=" + this.config.hostname;
+			if (this.config && this.config.hostname) new Image().src = "https://user-sync.adhese.com/handlers/" + option.syncName + "/user_sync_discovery?domain=" + this.config.hostname + "&tl=" + this.getBooleanConsent();
 			// this endpoint wil create a cookie on .adhese.com containing the domain as passed
 		}
 	}

--- a/src/rtb/ImproveDigitalUserSync.js
+++ b/src/rtb/ImproveDigitalUserSync.js
@@ -13,7 +13,7 @@ Adhese.prototype.improvedigitalUserSync = function(option) {
                 domain = option.domain;
        }
        this.genericUserSync({
-               url: "https://ad.360yield.com/server_match?partner_id=" + partner_id + "&r=https%3A%2F%2F" + domain + "%2Fhandlers%2Fimprovedigital%2Fuser_sync%3Fu%3D%7BPUB_USER_ID%7D",
+               url: "https://ad.360yield.com/server_match?partner_id=" + partner_id + "&r=https%3A%2F%2F" + domain + "%2Fhandlers%2Fimprovedigital%2Fuser_sync%3Ftl%3D" + this.getBooleanConsent() + "%26u%3D%7BPUB_USER_ID%7D",
                syncName: "improvedigital",
                iframe: true,
                onload: option.onload

--- a/src/rtb/MultiUserSync.js
+++ b/src/rtb/MultiUserSync.js
@@ -1,7 +1,7 @@
 Adhese.prototype.multiUserSync = function(option) {
     if (option && option.account) {
         this.genericUserSync({
-            url: "https://user-sync.adhese.com/iframe/user_sync.html?account=" + option.account,
+            url: "https://user-sync.adhese.com/iframe/user_sync.html?account=" + option.account + "&tl=" + this.getBooleanConsent(),
             syncName: "multi",
             iframe: true,
             onload: option.onload 

--- a/src/rtb/PubmaticUserSync.js
+++ b/src/rtb/PubmaticUserSync.js
@@ -6,7 +6,7 @@
 Adhese.prototype.pubmaticUserSync = function(option) {
         if (option && option.pubmatic_publisher_id) {
                 this.genericUserSync({
-                        url: "https://ads.pubmatic.com/AdServer/js/user_sync.html?p=" + option.pubmatic_publisher_id + "&predirect=https%3a%2f%2fuser-sync.adhese.com%2fhandlers%2fpubmatic%2fuser_sync%3fu%3d",
+                        url: "https://ads.pubmatic.com/AdServer/js/user_sync.html?p=" + option.pubmatic_publisher_id + "&predirect=https%3a%2f%2fuser-sync.adhese.com%2fhandlers%2fpubmatic%2fuser_sync%3ftl%3D" + this.getBooleanConsent() + "%26u%3d",
                         syncName: "pubmatic",
                         iframe: true,
                         onload: option.onload 

--- a/src/rtb/SpotxUserSync.js
+++ b/src/rtb/SpotxUserSync.js
@@ -10,7 +10,7 @@ Adhese.prototype.spotxUserSync = function(option) {
         }
         if (option && option.spotx_advertiser_id) {
                 this.genericUserSync({
-                        url: "https://sync.search.spotxchange.com/partner?adv_id=" + option.spotx_advertiser_id + "&redir=https%3A%2F%2F" + domain + "%2Fhandlers%2Fspotx%2Fuser_sync%3Fu%3D%24SPOTX_USER_ID",
+                        url: "https://sync.search.spotxchange.com/partner?adv_id=" + option.spotx_advertiser_id + "&redir=https%3A%2F%2F" + domain + "%2Fhandlers%2Fspotx%2Fuser_sync%3Ftl%3D" + this.getBooleanConsent() + "%26u%3D%24SPOTX_USER_ID",
                         syncName: "spotx",
                         iframe: true,
                         onload: option.onload 


### PR DESCRIPTION
So I added the boolean consent value to the user sync requests. Some SSP's however do not pick up our request dynamically, so I did not add it there, and it probably doesn't make much sense for them either, as we cannot pass them that value.