### PR TITLE
allow for previews of multiple formats

### DIFF
--- a/src/Adhese.js
+++ b/src/Adhese.js
@@ -204,28 +204,28 @@ Adhese.prototype.addRequestString = function(value) {
   	var ad = new this.Ad(this, formatCode, options);
 	 	
 	if (this.previewActive) {
- 		var pf = this.previewFormats
-		for (var key in pf) {
-			if (key  == formatCode) {
-				var previewformat = pf[formatCode];
-				// create Ad for preview
-				var previewAd = new this.Ad(this, formatCode, options);
-				previewAd.adType = formatCode;
-				previewAd.ext = "js";
-                var previewJsonRequest = "";
-                if(!previewAd.options.write)previewJsonRequest = "json/";
-                previewAd.swfSrc = that.config.previewHost + "/creatives/preview/"+previewJsonRequest+"tag.do?id=" + previewformat.creative + "&slotId=" + previewformat.slot;
-				previewAd.width = previewformat.width;
-				previewAd.height = previewformat.height;
-				ad = previewAd;
-				if (document.readyState === 'complete') {
-					this.showPreviewSign();
-				} else {
-					addEventListener("load", that.showPreviewSign.bind(that));
-				}
-			}
-		}
-	 }
+		var pf = this.previewFormats
+	   for (var key in pf) {
+		   if (key  == formatCode + (options.position?options.position:"")) {
+			   var previewformat = pf[formatCode + (options.position?options.position:"")];
+			   // create Ad for preview
+			   var previewAd = new this.Ad(this, formatCode, options);
+			   previewAd.adType = formatCode;
+			   previewAd.ext = "js";
+			   var previewJsonRequest = "";
+			   if(!previewAd.options.write)previewJsonRequest = "json/";
+			   previewAd.swfSrc = that.config.previewHost + "/creatives/preview/"+previewJsonRequest+"tag.do?id=" + previewformat.creative + "&slotId=" + previewformat.slot;
+			   previewAd.width = previewformat.width;
+			   previewAd.height = previewformat.height;
+			   ad = previewAd;
+			   if (document.readyState === 'complete') {
+				   this.showPreviewSign();
+			   } else {
+				   addEventListener("load", that.showPreviewSign.bind(that));
+			   }
+		   }
+	   }
+	}
 	 
  	this.ads.push([formatCode, ad]);
  	if (ad.options.write) {

--- a/src/Helper.js
+++ b/src/Helper.js
@@ -161,10 +161,10 @@ Adhese.prototype.Helper.prototype.debugTable = function() {
  * @param  {string} inName	The name of the parameter to read.
  * @return {array}	Returns an array of strings containing the values read from the location uri.
  */
- Adhese.prototype.Helper.prototype.getQueryStringParameter = function(inName) {
- 	var match = RegExp('[?&]' + key + '=([^&]*)').exec(window.location.search);
- 	return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : default_;
- };
+Adhese.prototype.Helper.prototype.getQueryStringParameter = function(inName) {
+	var match = RegExp('[?&]' + inName + '=([^&]*)').exec(window.location.search);
+	return match ? decodeURIComponent(match[1].replace(/\+/g, ' ')) : "";
+};
 
 /**
  * Creates img element of 1 pixel and adds it to the document outside the viewport.

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -84,11 +84,11 @@ Adhese.prototype.checkPreview = function () {
 };
 
 Adhese.prototype.checkPreviewList = function() {
-	this.helper.log("checking for preview in json format", this.helper.getQueryStringParameter("adhese_preview"));
+	this.helper.log("checking for preview in json format", this.helper.getQueryStringParameter("adhese_preview_list"));
 	
 	var previewAds = [];
-	var inUrl = this.helper.getQueryStringParameter("adhese_preview");
-	var inCookie = this.helper.readCookie("adhese_preview");
+	var inUrl = this.helper.getQueryStringParameter("adhese_preview_list");
+	var inCookie = this.helper.readCookie("adhese_preview_list");
 	if (inUrl != "" && inUrl != null)
 		previewAds = JSON.parse(inUrl);
 	else if (inCookie != "" && inCookie != null)
@@ -99,7 +99,7 @@ Adhese.prototype.checkPreviewList = function() {
 		this.previewFormats[ad.format+(ad.position?ad.position:"")] = {slot:(ad.slotId?ad.slotId:""),creative:ad.cId, templateFile:ad.format,width:0,height:0,position:(ad.position?ad.position:"")};
 	});	
 	
-	this.helper.createCookie("adhese_preview",JSON.stringify(previewAds),0);
+	this.helper.createCookie("adhese_preview_list",JSON.stringify(previewAds),0);
 	this.previewActive = previewAds.length>0;	
 }
 

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -110,7 +110,7 @@ Adhese.prototype.showPreviewSign = function () {
 	if (!document.getElementById("adhPreviewMessage")){
 		var that = this;
 		var p = document.createElement('DIV');
-		var msg = '<div id="adhPreviewMessage" style="cursor:pointer;font-family:Helvetica,Verdana; font-size:12px; text-align:center; background-color: #000000; color: #FFFFFF; position:fixed; top:10px;left:10px;padding:10px;z-index:9999;width: 100px;"><b>Adhese preview active.</br> Click to disable</div>';
+		var msg = '<div id="adhPreviewMessage" style="opacity: 0.4; cursor:pointer;font-family:Helvetica,Verdana; font-size:12px; text-align:center; background-color: #000000; color: #FFFFFF; position:fixed; top:10px;left:10px;padding:10px;z-index:9999;width: 100px;">ADHESE PREVIEW MODE<br/>clock to close</div>';
 		p.innerHTML = msg;
 		// once and afterload
 		document.body.appendChild(p);

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -79,7 +79,7 @@ Adhese.prototype.checkPreview = function () {
 		}
 		this.previewActive = true;
 	} else {
-		checkPreviewList();
+		this.checkPreviewList();
 	}
 };
 

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -89,9 +89,9 @@ Adhese.prototype.checkPreviewList = function() {
 	var previewAds = [];
 	var inUrl = this.helper.getQueryStringParameter("adhese_preview");
 	var inCookie = this.helper.readCookie("adhese_preview");
-	if (inUrl != "")
+	if (inUrl != "" && inUrl != null)
 		previewAds = JSON.parse(inUrl);
-	else if (inCookie != "")
+	else if (inCookie != "" && inCookie != null)
 		previewAds = JSON.parse(inCookie);
 	
 	this.previewFormats = {};

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -124,9 +124,9 @@ Adhese.prototype.showPreviewSign = function () {
 Adhese.prototype.closePreviewSign = function () {
 	this.helper.eraseCookie("adhese_preview");
 	this.helper.eraseCookie("adhese_preview_list");
-	if(location.search.indexOf("adhesePreviewCreativeId") != -1){
+	if(location.search.indexOf("adhesePreviewCreativeId") != -1 || location.search.indexOf("adhese_preview_list") != -1){
 		location.href = location.href.split("?")[0];
-	}else{
+	} else {
 		location.reload();
 	}
 };

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -123,6 +123,7 @@ Adhese.prototype.showPreviewSign = function () {
  */
 Adhese.prototype.closePreviewSign = function () {
 	this.helper.eraseCookie("adhese_preview");
+	this.helper.eraseCookie("adhese_preview_list");
 	if(location.search.indexOf("adhesePreviewCreativeId") != -1){
 		location.href = location.href.split("?")[0];
 	}else{

--- a/src/Preview.js
+++ b/src/Preview.js
@@ -78,8 +78,30 @@ Adhese.prototype.checkPreview = function () {
 			this.previewFormats[c[0]] = {creative: c[1], slot: c[2], template: c[3], width: c[4], height: c[5]};
 		}
 		this.previewActive = true;
+	} else {
+		checkPreviewList();
 	}
 };
+
+Adhese.prototype.checkPreviewList = function() {
+	this.helper.log("checking for preview in json format", this.helper.getQueryStringParameter("adhese_preview"));
+	
+	var previewAds = [];
+	var inUrl = this.helper.getQueryStringParameter("adhese_preview");
+	var inCookie = this.helper.readCookie("adhese_preview");
+	if (inUrl != "")
+		previewAds = JSON.parse(inUrl);
+	else if (inCookie != "")
+		previewAds = JSON.parse(inCookie);
+	
+	this.previewFormats = {};
+	previewAds.forEach(ad => {
+		this.previewFormats[ad.format+(ad.position?ad.position:"")] = {slot:(ad.slotId?ad.slotId:""),creative:ad.cId, templateFile:ad.format,width:0,height:0,position:(ad.position?ad.position:"")};
+	});	
+	
+	this.helper.createCookie("adhese_preview",JSON.stringify(previewAds),0);
+	this.previewActive = previewAds.length>0;	
+}
 
 /**
  * The showPreviewSign function displays a message to inform the user that the live preview is active.


### PR DESCRIPTION
To support preview of multiple slots on one page, I created a new url paranmeter that contains a json object.
Example: adhese_preview=[{"cId":543,"format":"banner_bottom"},{"cId":542,"format":"banner_top"},{"cId":541,"format":"banner_action"}]

Based on the items in the object, we execute single requests to the json preview endpoint (for each cerative) and render the results in the corresponding containers.

